### PR TITLE
fix: carousel template title must not be longer than 40 characters

### DIFF
--- a/src/message/KKBOXMessage.js
+++ b/src/message/KKBOXMessage.js
@@ -10,7 +10,7 @@ module.exports = class KKBOXMessage extends Message {
         const columns = this.data.map(el => {
             return {
                 thumbnailImageUrl: el.images === undefined ? el.album.images[1].url : el.images[1].url,
-                title: el.name === undefined ? el.title : el.name,
+                title: el.name === undefined ? el.title.slice(0, 40) : el.name.slice(0, 40),
                 text: el.description === undefined || el.description === '' ? ' ' : el.description.slice(0, 60),
                 actions: [{
                     type: 'uri',


### PR DESCRIPTION
error message:

```
Response -
  400 Bad Request

Response Data -
  {
    "message": "A message (messages[0]) in the request body is invalid",
    "details": [
      {
        "message": "must not be longer than 40 characters",
        "property": "template/columns/5/title"
      }
    ]
  }
```